### PR TITLE
Setup: Fix TCs to work with this.runBroadcast

### DIFF
--- a/chat-plugins/ez-tc.js
+++ b/chat-plugins/ez-tc.js
@@ -39,7 +39,7 @@ exports.commands = {
 				var commandName = toId(parts[1]);
 				if (CommandParser.commands[commandName]) return this.sendReply("/trainercards - The command \"" + commandName + "\" already exists.");
 				var html = parts.splice(2, parts.length).join(',');
-				trainerCards[commandName] = new Function('target', 'room', 'user', "if (!room.disableTrainerCards) if (!this.canBroadcast()) return; this.sendReplyBox('" + html.replace(/'/g, "\\'") + "');");
+				trainerCards[commandName] = new Function('target', 'room', 'user', "if (!room.disableTrainerCards) if (!this.runBroadcast()) return; this.sendReplyBox('" + html.replace(/'/g, "\\'") + "');");
 				saveTrainerCards();
 				this.sendReply("The trainer card \"" + commandName + "\" has been added.");
 				this.logModCommand(user.name + " added the trainer card " + commandName);


### PR DESCRIPTION
I saw in ez-tc.js that whenever you make a tc, it will copy over to the trainercards.json in the Config folder as this.canBroadcast. If people actually broadcast it with canBroadcast being defined, then it will cause some problems in which people can't be able to broadcast other commands.
